### PR TITLE
fix OCL data display format

### DIFF
--- a/src/components/content/register/DisplayOclData.tsx
+++ b/src/components/content/register/DisplayOclData.tsx
@@ -77,23 +77,27 @@ function DisplayOclData({ ocl }: { ocl: Ocl }): JSX.Element | string {
                                 <br />
                                 <b>Service Name</b>
                                 <br />
-                                <Tag color='blue'>{ocl.name}</Tag>
+                                <Tag className={'ocl-display-tag'} color='blue'>
+                                    {ocl.name}
+                                </Tag>
                                 <br />
                                 <br />
                             </div>
                             <div>
                                 <b>Cloud Service Provider</b>
                                 <br />
-                                <Tag color='cyan'>{ocl.cloudServiceProvider.name}</Tag>
+                                <Tag className={'ocl-display-tag'} color='cyan'>
+                                    {ocl.cloudServiceProvider.name}
+                                </Tag>
                                 <br />
                                 <br />
                             </div>
                             <div>
                                 <b>Available Regions</b>
                                 <br />
-                                {ocl.cloudServiceProvider.regions.map((region, index) => (
-                                    <Tag color='orange'>
-                                        {region.area}:&nbsp;{region.name}
+                                {ocl.cloudServiceProvider.regions.map((region) => (
+                                    <Tag className={'ocl-display-tag'} color='orange'>
+                                        {region.area ? `${region.area}: ${region.name}` : region.name}
                                     </Tag>
                                 ))}
                                 <br />

--- a/src/styles/register.css
+++ b/src/styles/register.css
@@ -20,3 +20,7 @@
 .ant-upload-list-item-name {
     padding: 0 !important;
 }
+
+.ocl-display-tag {
+    margin-top: 10px;
+}


### PR DESCRIPTION
fixed to handle optional 'area' field in region.
Added spacing for tags.

![image](https://user-images.githubusercontent.com/54129659/228478698-daab87f2-60fe-4ac7-ba21-be3a2c15c1ae.png)
