### PR TITLE
Display errors as a list

### DIFF
--- a/src/components/content/catalog/services/UpdateResult.tsx
+++ b/src/components/content/catalog/services/UpdateResult.tsx
@@ -6,6 +6,7 @@
 import { Alert, Button } from 'antd';
 import { Ocl } from '../../../../xpanse-api/generated';
 import { ValidationStatus } from '../../register/ValidationStatus';
+import { convertStringArrayToUnorderedList } from '../../../utils/generateUnorderedList';
 
 function UpdateResult({
     ocl,
@@ -15,7 +16,7 @@ function UpdateResult({
 }: {
     ocl: Ocl;
     updateRequestStatus: ValidationStatus;
-    updateResult: string;
+    updateResult: string[];
     onRemove: () => void;
 }): JSX.Element {
     if (updateRequestStatus === 'completed') {
@@ -26,6 +27,7 @@ function UpdateResult({
                 closable={true}
                 onClose={onRemove}
                 className={'result'}
+                description={convertStringArrayToUnorderedList(updateResult)}
             />
         );
     } else if (updateRequestStatus === 'error') {
@@ -35,7 +37,7 @@ function UpdateResult({
                 closable={true}
                 showIcon={true}
                 message={`Service Update Failed`}
-                description={updateResult}
+                description={convertStringArrayToUnorderedList(updateResult)}
                 onClose={onRemove}
                 className={'result'}
                 action={

--- a/src/components/content/catalog/services/UpdateService.tsx
+++ b/src/components/content/catalog/services/UpdateService.tsx
@@ -26,7 +26,7 @@ function UpdateService({
     const files = useRef<UploadFile[]>([]);
     const yamlValidationResult = useRef<string>('');
     const oclDisplayData = useRef<JSX.Element>(<></>);
-    const updateResult = useRef<string>('');
+    const updateResult = useRef<string[]>([]);
     const [yamlSyntaxValidationStatus, setYamlSyntaxValidationStatus] = useState<ValidationStatus>('notStarted');
     const [oclValidationStatus, setOclValidationStatus] = useState<ValidationStatus>('notStarted');
     const [updateRequestStatus, setUpdateRequestStatus] = useState<ValidationStatus>('notStarted');
@@ -48,7 +48,7 @@ function UpdateService({
         files.current.pop();
         ocl.current = undefined;
         yamlValidationResult.current = '';
-        updateResult.current = '';
+        updateResult.current = [];
         setYamlSyntaxValidationStatus('notStarted');
         setOclValidationStatus('notStarted');
         setUpdateRequestStatus('notStarted');
@@ -107,7 +107,7 @@ function UpdateService({
         files.current.pop();
         ocl.current = undefined;
         yamlValidationResult.current = '';
-        updateResult.current = '';
+        updateResult.current = [];
         setYamlSyntaxValidationStatus('notStarted');
         setOclValidationStatus('notStarted');
         setUpdateRequestStatus('notStarted');

--- a/src/components/content/catalog/services/updateServiceResult.ts
+++ b/src/components/content/catalog/services/updateServiceResult.ts
@@ -4,7 +4,7 @@
  */
 
 import { MutableRefObject } from 'react';
-import { Ocl } from '../../../../xpanse-api/generated';
+import { ApiException, Ocl, Response } from '../../../../xpanse-api/generated';
 import { ValidationStatus } from '../../register/ValidationStatus';
 import { UploadFile } from 'antd';
 import { serviceVendorApi } from '../../../../xpanse-api/xpanseRestApiClient';
@@ -13,7 +13,7 @@ export function updateServiceResult(
     id: string,
     ocl: Ocl,
     setUpdateRequestStatus: (newState: ValidationStatus) => void,
-    updateResult: MutableRefObject<string>,
+    updateResult: MutableRefObject<string[]>,
     file: UploadFile
 ): void {
     setUpdateRequestStatus('inProgress');
@@ -22,11 +22,15 @@ export function updateServiceResult(
         .then(() => {
             file.status = 'success';
             setUpdateRequestStatus('completed');
-            updateResult.current = 'Service updated Successfully';
+            updateResult.current = [`ID - ${id}`];
         })
         .catch((error: Error) => {
             file.status = 'error';
             setUpdateRequestStatus('error');
-            updateResult.current = error.message;
+            if (error instanceof ApiException && error.body instanceof Response) {
+                updateResult.current = error.body.details;
+            } else {
+                updateResult.current = [error.message];
+            }
         });
 }

--- a/src/components/content/register/RegisterPanel.tsx
+++ b/src/components/content/register/RegisterPanel.tsx
@@ -21,7 +21,7 @@ function RegisterPanel(): JSX.Element {
     const files = useRef<UploadFile[]>([]);
     const yamlValidationResult = useRef<string>('');
     const oclDisplayData = useRef<JSX.Element>(<></>);
-    const registerResult = useRef<string>('');
+    const registerResult = useRef<string[]>([]);
     const [yamlSyntaxValidationStatus, setYamlSyntaxValidationStatus] = useState<ValidationStatus>('notStarted');
     const [oclValidationStatus, setOclValidationStatus] = useState<ValidationStatus>('notStarted');
     const [registerRequestStatus, setRegisterRequestStatus] = useState<ValidationStatus>('notStarted');
@@ -76,7 +76,7 @@ function RegisterPanel(): JSX.Element {
         files.current.pop();
         ocl.current = undefined;
         yamlValidationResult.current = '';
-        registerResult.current = '';
+        registerResult.current = [];
         setYamlSyntaxValidationStatus('notStarted');
         setOclValidationStatus('notStarted');
         setRegisterRequestStatus('notStarted');

--- a/src/components/content/register/RegisterResult.tsx
+++ b/src/components/content/register/RegisterResult.tsx
@@ -6,6 +6,7 @@
 import { Alert, Button } from 'antd';
 import { Ocl } from '../../../xpanse-api/generated';
 import { ValidationStatus } from './ValidationStatus';
+import { convertStringArrayToUnorderedList } from '../../utils/generateUnorderedList';
 
 function RegisterResult({
     ocl,
@@ -15,7 +16,7 @@ function RegisterResult({
 }: {
     ocl: Ocl;
     registerRequestStatus: ValidationStatus;
-    registerResult: string;
+    registerResult: string[];
     onRemove: () => void;
 }): JSX.Element {
     if (registerRequestStatus === 'completed') {
@@ -30,7 +31,7 @@ function RegisterResult({
                 closable={true}
                 onClose={onRemove}
                 className={'result'}
-                description={registerResult}
+                description={convertStringArrayToUnorderedList(registerResult)}
             />
         );
     } else if (registerRequestStatus === 'error') {
@@ -40,7 +41,7 @@ function RegisterResult({
                 closable={true}
                 showIcon={true}
                 message={`Service Registration Failed`}
-                description={registerResult}
+                description={convertStringArrayToUnorderedList(registerResult)}
                 onClose={onRemove}
                 className={'result'}
                 action={

--- a/src/components/content/register/registerService.ts
+++ b/src/components/content/register/registerService.ts
@@ -12,7 +12,7 @@ import { ApiException, Ocl, RegisteredServiceVo, Response } from '../../../xpans
 export function registerService(
     ocl: Ocl,
     setRegisterRequestStatus: (newState: ValidationStatus) => void,
-    registerResult: MutableRefObject<string>,
+    registerResult: MutableRefObject<string[]>,
     file: UploadFile
 ): void {
     setRegisterRequestStatus('inProgress');
@@ -21,15 +21,15 @@ export function registerService(
         .then((registeredServiceVo: RegisteredServiceVo) => {
             file.status = 'success';
             setRegisterRequestStatus('completed');
-            registerResult.current = `ID - ${registeredServiceVo.id}`;
+            registerResult.current = [`ID - ${registeredServiceVo.id}`];
         })
         .catch((error: Error) => {
             file.status = 'error';
             setRegisterRequestStatus('error');
             if (error instanceof ApiException && error.body instanceof Response) {
-                registerResult.current = error.body.details.join(',');
+                registerResult.current = error.body.details;
             } else {
-                registerResult.current = error.message;
+                registerResult.current = [error.message];
             }
         });
 }

--- a/src/components/utils/generateUnorderedList.tsx
+++ b/src/components/utils/generateUnorderedList.tsx
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+export function convertStringArrayToUnorderedList(result: string[]): string | JSX.Element {
+    if (result.length === 1) {
+        return result[0];
+    }
+    if (result.length > 1) {
+        const items: JSX.Element[] = [];
+        result.forEach((item) => items.push(<li>{item}</li>));
+        return <ul>{items}</ul>;
+    }
+    return '';
+}


### PR DESCRIPTION
1. Display errors as  list. 
2. Unify display structure for update and register.

![image](https://user-images.githubusercontent.com/54129659/232758248-eda2f9ad-58fa-47a1-b5b6-fc4c30c79ed1.png)

![image](https://user-images.githubusercontent.com/54129659/232758389-6b45ddab-c098-4991-a3b1-d4f9f225e95c.png)
