### PR TITLE
display skeleton when services are loaded

### DIFF
--- a/src/components/content/order/Services.tsx
+++ b/src/components/content/order/Services.tsx
@@ -13,11 +13,13 @@ import { Col, Empty, Row } from 'antd';
 import { Badge, Space } from 'antd';
 import { sortVersion } from '../../utils/Sort';
 import { ServiceVoCategoryEnum, VersionOclVo } from '../../../xpanse-api/generated';
+import ServicesSkeleton from './ServicesSkeleton';
 
 function Services(): JSX.Element {
     const [services, setServices] = useState<{ name: string; content: string; icon: string; latestVersion: string }[]>(
         []
     );
+    const [isServicesLoaded, setIsServicesLoaded] = useState<boolean>(false);
     const navigate = useNavigate();
     const location = useLocation();
 
@@ -39,6 +41,7 @@ function Services(): JSX.Element {
     }
 
     useEffect(() => {
+        setIsServicesLoaded(false);
         const categoryName = location.hash.split('#')[1] as ServiceVoCategoryEnum;
         void servicesAvailableApi.getAvailableServicesTree(categoryName).then((rsp) => {
             const serviceList: { name: string; content: string; icon: string; latestVersion: string }[] = [];
@@ -53,63 +56,66 @@ function Services(): JSX.Element {
                     serviceList.push(serviceItem);
                 });
                 setServices(serviceList);
+                setIsServicesLoaded(true);
             } else {
                 setServices(serviceList);
+                setIsServicesLoaded(true);
             }
         });
     }, [location]);
 
     return (
         <>
-            {services.length > 0 ? (
-                <div className={'services-content'}>
-                    <div className={'content-title'}>
-                        <FormOutlined />
-                        &nbsp;Select Service
-                    </div>
+            {' '}
+            {isServicesLoaded ? (
+                services.length > 0 ? (
+                    <div className={'services-content'}>
+                        <div className={'content-title'}>
+                            <FormOutlined />
+                            &nbsp;Select Service
+                        </div>
 
-                    <div className={'services-content-body'}>
-                        {services.map((item, index) => {
-                            return (
-                                <Row key={index}>
-                                    <Col span={8} className={'services-content-body-col'}>
-                                        <Space
-                                            direction='vertical'
-                                            size='middle'
-                                            className={'services-content-body-space'}
-                                        >
-                                            <Badge.Ribbon text={item.latestVersion}>
-                                                <div
-                                                    key={index}
-                                                    className={'service-type-option-detail'}
-                                                    onClick={() => onSelectService(item.name, item.latestVersion)}
-                                                >
-                                                    <div className='service-type-option-image'>
-                                                        <img
-                                                            className='service-type-option-service-icon'
-                                                            src={item.icon}
-                                                            alt={'App'}
-                                                        />
+                        <div className={'services-content-body'}>
+                            {services.map((item, index) => {
+                                return (
+                                    <Row key={index}>
+                                        <Col span={8} className={'services-content-body-col'}>
+                                            <Space direction='vertical' size='middle'>
+                                                <Badge.Ribbon text={item.latestVersion}>
+                                                    <div
+                                                        key={index}
+                                                        className={'service-type-option-detail'}
+                                                        onClick={() => onSelectService(item.name, item.latestVersion)}
+                                                    >
+                                                        <div className='service-type-option-image'>
+                                                            <img
+                                                                className='service-type-option-service-icon'
+                                                                src={item.icon}
+                                                                alt={'App'}
+                                                            />
+                                                        </div>
+                                                        <div className='service-type-option-info'>
+                                                            <span className='service-type-option'>{item.name}</span>
+                                                            <span className='service-type-option-description'>
+                                                                {item.content}
+                                                            </span>
+                                                        </div>
                                                     </div>
-                                                    <div className='service-type-option-info'>
-                                                        <span className='service-type-option'>{item.name}</span>
-                                                        <span className='service-type-option-description'>
-                                                            {item.content}
-                                                        </span>
-                                                    </div>
-                                                </div>
-                                            </Badge.Ribbon>
-                                        </Space>
-                                    </Col>
-                                </Row>
-                            );
-                        })}
+                                                </Badge.Ribbon>
+                                            </Space>
+                                        </Col>
+                                    </Row>
+                                );
+                            })}
+                        </div>
                     </div>
-                </div>
+                ) : (
+                    <div className={'service-blank-class'}>
+                        <Empty description={'No services available.'} />
+                    </div>
+                )
             ) : (
-                <div className={'service-blank-class'}>
-                    <Empty description={'No services available.'} />
-                </div>
+                <ServicesSkeleton />
             )}
         </>
     );

--- a/src/components/content/order/ServicesSkeleton.tsx
+++ b/src/components/content/order/ServicesSkeleton.tsx
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+import { Col, Row, Skeleton, Space } from 'antd';
+
+function ServicesSkeleton() {
+    return (
+        <div className={'services-content'}>
+            <div className={'content-title'}>
+                <Skeleton active={true} paragraph={{ rows: 0 }} />
+            </div>
+            <div className={'services-content-body'}>
+                {Array.from({ length: 9 }, () => (
+                    <Row key={0}>
+                        <Col span={8} className={'services-content-body-col'}>
+                            <Space direction='vertical' size='middle'>
+                                <div className={'service-type-option-detail-skeleton ant-skeleton-header'}>
+                                    <Skeleton avatar={true} active={true} paragraph={{ rows: 1 }} />
+                                </div>
+                            </Space>
+                        </Col>
+                    </Row>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export default ServicesSkeleton;

--- a/src/styles/service_order.css
+++ b/src/styles/service_order.css
@@ -98,6 +98,18 @@
     border: 1px solid #edeeee;
 }
 
+.service-type-option-detail-skeleton {
+    flex-flow: nowrap row;
+    padding: 10px;
+    width: 300px;
+    height: 100px;
+    border: 1px solid #edeeee;
+}
+
+.service-type-option-detail-skeleton .ant-skeleton-header {
+    padding-top: 20px;
+}
+
 .service-type-option-detail:hover {
     cursor: pointer;
     display: flex;


### PR DESCRIPTION
Currently we display "no services available" while the services are being loaded in the background.  

Replaced that with a skeleton which will be displayed until service returns response. 
Note - this is an moving image. Screenshot does not reflect it.

![image](https://user-images.githubusercontent.com/54129659/233111864-c7f984f0-5f27-4614-8f50-18f8651c4269.png)
