### PR TITLE
display errors returned from deploy request

### DIFF
--- a/src/components/content/order/DeploymentSuccessful.tsx
+++ b/src/components/content/order/DeploymentSuccessful.tsx
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+import { ServiceDetailVo } from '../../../xpanse-api/generated';
+import { convertMapToUnorderedList } from '../../utils/generateUnorderedList';
+
+function DeploymentSuccessful(response: ServiceDetailVo): JSX.Element {
+    const endPointMap = new Map<string, string>();
+    if (response.deployedServiceProperties) {
+        for (const key in response.deployedServiceProperties) {
+            endPointMap.set(key, response.deployedServiceProperties[key]);
+        }
+    }
+    if (endPointMap.size > 0) {
+        return (
+            <div>
+                <span>{'Deployment Successful'}</span>
+                <div>{convertMapToUnorderedList(endPointMap, 'Endpoint Information')}</div>
+            </div>
+        );
+    } else {
+        return <span>{'Deployment Successful'}</span>;
+    }
+}
+
+export default DeploymentSuccessful;

--- a/src/components/content/order/OrderSubmitFailed.tsx
+++ b/src/components/content/order/OrderSubmitFailed.tsx
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+import OrderSubmitResult from './OrderSubmitResult';
+import { convertStringArrayToUnorderedList } from '../../utils/generateUnorderedList';
+import { ApiError, Response } from '../../../xpanse-api/generated';
+
+function getOrderSubmissionFailedDisplay(reasons: string[]) {
+    return (
+        <div>
+            <span>{'Service deployment request failed.'}</span>
+            <div>{convertStringArrayToUnorderedList(reasons)}</div>
+        </div>
+    );
+}
+function OrderSubmitFailed(error: Error): JSX.Element {
+    if (error instanceof ApiError && 'details' in error.body) {
+        const response: Response = error.body as Response;
+        return OrderSubmitResult(getOrderSubmissionFailedDisplay(response.details), '-', 'error');
+    }
+    return OrderSubmitResult(getOrderSubmissionFailedDisplay([error.message]), '-', 'error');
+}
+
+export default OrderSubmitFailed;

--- a/src/components/content/order/OrderSubmitResult.tsx
+++ b/src/components/content/order/OrderSubmitResult.tsx
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+import { Alert } from 'antd';
+import OrderSubmitResultDetails from './OrderSubmitResultDetails';
+
+function OrderSubmitResult(msg: string | JSX.Element, uuid: string, type: 'success' | 'error'): JSX.Element {
+    return (
+        <div className={'submit-alert-tip'}>
+            {' '}
+            <Alert
+                message={`Deployment Status`}
+                description={<OrderSubmitResultDetails msg={msg} uuid={uuid} />}
+                showIcon
+                type={type}
+            />{' '}
+        </div>
+    );
+}
+
+export default OrderSubmitResult;

--- a/src/components/content/order/OrderSubmitResultDetails.tsx
+++ b/src/components/content/order/OrderSubmitResultDetails.tsx
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+function OrderSubmitResultDetails({ msg, uuid }: { msg: string | JSX.Element; uuid: string }): JSX.Element {
+    return (
+        <>
+            Request ID: <b>{uuid}</b>
+            <br />
+            {msg}
+        </>
+    );
+}
+
+export default OrderSubmitResultDetails;


### PR DESCRIPTION
errors returned by deploy request is now displayed in the GUI. These are the sync response returned in the deploy request. 

While implementing this, it was also necessary to refactor the deployment result components. I have only split them into separate components. 

![image](https://user-images.githubusercontent.com/54129659/236190195-c589f9c5-0d0a-4588-a4cf-72cb7bbcd82b.png)
