### PR TITLE
control access to pages based on roles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ function App(): JSX.Element {
             <Route
                 path={homePageRoute}
                 element={
-                    <Protected>
+                    <Protected allowedRole={'all'}>
                         <Home />
                     </Protected>
                 }
@@ -40,7 +40,7 @@ function App(): JSX.Element {
             <Route
                 path={registerPageRoute}
                 element={
-                    <Protected>
+                    <Protected allowedRole={'csp'}>
                         <RegisterPanel />
                     </Protected>
                 }
@@ -48,7 +48,7 @@ function App(): JSX.Element {
             <Route
                 path={catalogPageRoute}
                 element={
-                    <Protected>
+                    <Protected allowedRole={'csp'}>
                         <Catalog />
                     </Protected>
                 }
@@ -56,7 +56,7 @@ function App(): JSX.Element {
             <Route
                 path={orderPageRoute}
                 element={
-                    <Protected>
+                    <Protected allowedRole={'user'}>
                         <OrderSubmitPage />
                     </Protected>
                 }
@@ -64,7 +64,7 @@ function App(): JSX.Element {
             <Route
                 path={servicesPageRoute}
                 element={
-                    <Protected>
+                    <Protected allowedRole={'user'}>
                         <Services />
                     </Protected>
                 }
@@ -72,7 +72,7 @@ function App(): JSX.Element {
             <Route
                 path={myServicesRoute}
                 element={
-                    <Protected>
+                    <Protected allowedRole={'user'}>
                         <ServiceList />
                     </Protected>
                 }
@@ -80,7 +80,7 @@ function App(): JSX.Element {
             <Route
                 path={createServicePageRoute}
                 element={
-                    <Protected>
+                    <Protected allowedRole={'user'}>
                         <CreateService />
                     </Protected>
                 }
@@ -88,7 +88,7 @@ function App(): JSX.Element {
             <Route
                 path={monitorPageRoute}
                 element={
-                    <Protected>
+                    <Protected allowedRole={'user'}>
                         <Monitor />
                     </Protected>
                 }

--- a/src/components/content/login/LoginScreen.tsx
+++ b/src/components/content/login/LoginScreen.tsx
@@ -11,7 +11,7 @@ import { useForm } from 'antd/es/form/Form';
 import { Location } from '@remix-run/router';
 
 function LoginScreen(): JSX.Element {
-    const validUsers: string[] = ['csp', 'user', 'otc'];
+    const validUsers: string[] = ['csp', 'user'];
     const [loginForm] = useForm();
     const location: Location = useLocation();
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/src/components/protectedRoutes/NotAuthorized.tsx
+++ b/src/components/protectedRoutes/NotAuthorized.tsx
@@ -1,0 +1,20 @@
+import { Button, Result } from 'antd';
+import { useNavigate } from 'react-router-dom';
+
+function NotAuthorized(): JSX.Element {
+    const navigate = useNavigate();
+
+    return (
+        <Result
+            status='warning'
+            title='User not authorized to view this page'
+            extra={
+                <Button type='primary' key='console' onClick={() => navigate(-1)}>
+                    Go Back
+                </Button>
+            }
+        />
+    );
+}
+
+export default NotAuthorized;

--- a/src/components/protectedRoutes/ProtectedRoute.tsx
+++ b/src/components/protectedRoutes/ProtectedRoute.tsx
@@ -8,10 +8,27 @@ import { Layout } from 'antd';
 import LayoutFooter from '../layouts/footer/LayoutFooter';
 import LayoutHeader from '../layouts/header/LayoutHeader';
 import LayoutSider from '../layouts/sider/LayoutSider';
-import { isAuthenticatedKey, loginPageRoute } from '../utils/constants';
+import { isAuthenticatedKey, loginPageRoute, usernameKey } from '../utils/constants';
+import NotAuthorized from './NotAuthorized';
 
 interface ProtectedRouteProperties {
     children: JSX.Element;
+    allowedRole: 'csp' | 'user' | 'all';
+}
+
+function getFullLayout(content: JSX.Element): JSX.Element {
+    return (
+        <Layout className={'layout'} hasSider={true}>
+            <LayoutSider />
+            <Layout>
+                <LayoutHeader />
+                <Layout.Content className={'site-layout'}>
+                    <div className={'site-layout-background'}>{content}</div>
+                </Layout.Content>
+                <LayoutFooter />
+            </Layout>
+        </Layout>
+    );
 }
 
 function Protected(protectedRouteProperties: ProtectedRouteProperties): JSX.Element {
@@ -22,18 +39,13 @@ function Protected(protectedRouteProperties: ProtectedRouteProperties): JSX.Elem
     ) {
         return <Navigate to={loginPageRoute} replace={true} state={{ from: location }} />;
     }
-    return (
-        <Layout className={'layout'} hasSider={true}>
-            <LayoutSider />
-            <Layout>
-                <LayoutHeader />
-                <Layout.Content className={'site-layout'}>
-                    <div className={'site-layout-background'}>{protectedRouteProperties.children}</div>
-                </Layout.Content>
-                <LayoutFooter />
-            </Layout>
-        </Layout>
-    );
+    if (
+        localStorage.getItem(usernameKey) !== protectedRouteProperties.allowedRole &&
+        protectedRouteProperties.allowedRole !== 'all'
+    ) {
+        return getFullLayout(<NotAuthorized />);
+    }
+    return getFullLayout(protectedRouteProperties.children);
 }
 
 export default Protected;


### PR DESCRIPTION
Fixes eclipse-xpanse/xpanse#384

This PR now checks the allowed role for each page. If someone force switches to a page for which he is not allowed to, we will display the below error.

![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/54129659/028a424a-903d-43b7-a27f-3ee7cfd8eb52)
