### PR TITLE
replace API calls to react-query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-router-dom": "^6.14.1",
+                "react-timer-hook": "^3.0.7",
                 "web-vitals": "^2.1.4",
                 "yaml": "^2.2.2"
             },
@@ -17484,6 +17485,14 @@
                 "node": ">=10"
             }
         },
+        "node_modules/react-timer-hook": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/react-timer-hook/-/react-timer-hook-3.0.7.tgz",
+            "integrity": "sha512-ATpNcU+PQRxxfNBPVqce2+REtjGAlwmfoNQfcEBMZFxPj0r3GYdKhyPHdStvqrejejEi0QvqaJZjy2lBlFvAsA==",
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
         "node_modules/read-cache": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -33589,6 +33598,12 @@
                     "dev": true
                 }
             }
+        },
+        "react-timer-hook": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/react-timer-hook/-/react-timer-hook-3.0.7.tgz",
+            "integrity": "sha512-ATpNcU+PQRxxfNBPVqce2+REtjGAlwmfoNQfcEBMZFxPj0r3GYdKhyPHdStvqrejejEi0QvqaJZjy2lBlFvAsA==",
+            "requires": {}
         },
         "read-cache": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.1",
+        "react-timer-hook": "^3.0.7",
         "web-vitals": "^2.1.4",
         "yaml": "^2.2.2"
     },

--- a/src/components/content/order/DeploymentTimer.tsx
+++ b/src/components/content/order/DeploymentTimer.tsx
@@ -1,0 +1,33 @@
+import { StopwatchResult } from 'react-timer-hook';
+import { ServiceDetailVo } from '../../../xpanse-api/generated';
+import { useEffect } from 'react';
+import { HourglassOutlined } from '@ant-design/icons';
+
+function DeploymentTimer({
+    stopWatch,
+    deploymentStatus,
+}: {
+    stopWatch: StopwatchResult;
+    deploymentStatus: ServiceDetailVo.serviceDeploymentState;
+}) {
+    useEffect(() => {
+        if (stopWatch.isRunning && deploymentStatus !== ServiceDetailVo.serviceDeploymentState.DEPLOYING) {
+            stopWatch.pause();
+        }
+        if (!stopWatch.isRunning && deploymentStatus === ServiceDetailVo.serviceDeploymentState.DEPLOYING) {
+            stopWatch.reset();
+        }
+    }, [deploymentStatus, stopWatch]);
+
+    return (
+        <div className={'timer-block'}>
+            <div className={'timer-header'}>Deployment Duration</div>
+            <div className={'timer-value'}>
+                <HourglassOutlined /> <span>{stopWatch.hours}h</span>:<span>{stopWatch.minutes}m</span>:
+                <span>{stopWatch.seconds}s</span>
+            </div>
+        </div>
+    );
+}
+
+export default DeploymentTimer;

--- a/src/components/content/order/OrderSubmitFailed.tsx
+++ b/src/components/content/order/OrderSubmitFailed.tsx
@@ -5,7 +5,8 @@
 
 import { MigrateSubmitResult, OrderSubmitResult } from './OrderSubmitResult';
 import { convertStringArrayToUnorderedList } from '../../utils/generateUnorderedList';
-import { ApiError, Response } from '../../../xpanse-api/generated';
+import { ApiError, Response, ServiceDetailVo } from '../../../xpanse-api/generated';
+import { StopwatchResult } from 'react-timer-hook';
 
 function getOrderSubmissionFailedDisplay(reasons: string[]) {
     return (
@@ -15,12 +16,28 @@ function getOrderSubmissionFailedDisplay(reasons: string[]) {
         </div>
     );
 }
-export function OrderSubmitFailed(error: Error): JSX.Element {
+export function OrderSubmitFailed(
+    error: Error,
+    deploymentStatus: ServiceDetailVo.serviceDeploymentState,
+    stopWatch: StopwatchResult
+): JSX.Element {
     if (error instanceof ApiError && 'details' in error.body) {
         const response: Response = error.body as Response;
-        return OrderSubmitResult(getOrderSubmissionFailedDisplay(response.details), '-', 'error');
+        return OrderSubmitResult(
+            getOrderSubmissionFailedDisplay(response.details),
+            '-',
+            'error',
+            deploymentStatus,
+            stopWatch
+        );
     }
-    return OrderSubmitResult(getOrderSubmissionFailedDisplay([error.message]), '-', 'error');
+    return OrderSubmitResult(
+        getOrderSubmissionFailedDisplay([error.message]),
+        '-',
+        'error',
+        deploymentStatus,
+        stopWatch
+    );
 }
 
 export const MigrateSubmitFailed = (error: Error): JSX.Element => {

--- a/src/components/content/order/OrderSubmitResult.tsx
+++ b/src/components/content/order/OrderSubmitResult.tsx
@@ -5,8 +5,17 @@
 
 import { Alert } from 'antd';
 import OrderSubmitResultDetails from './OrderSubmitResultDetails';
+import { StopwatchResult } from 'react-timer-hook';
+import { ServiceDetailVo } from '../../../xpanse-api/generated';
+import DeploymentTimer from './DeploymentTimer';
 
-export const OrderSubmitResult = (msg: string | JSX.Element, uuid: string, type: 'success' | 'error'): JSX.Element => {
+export const OrderSubmitResult = (
+    msg: string | JSX.Element,
+    uuid: string,
+    type: 'success' | 'error',
+    deploymentStatus: ServiceDetailVo.serviceDeploymentState,
+    stopWatch: StopwatchResult
+): JSX.Element => {
     return (
         <div className={'submit-alert-tip'}>
             {' '}
@@ -14,8 +23,9 @@ export const OrderSubmitResult = (msg: string | JSX.Element, uuid: string, type:
                 message={`Processing Status`}
                 description={<OrderSubmitResultDetails msg={msg} uuid={uuid} />}
                 showIcon
-                closable
+                closable={false}
                 type={type}
+                action={<DeploymentTimer stopWatch={stopWatch} deploymentStatus={deploymentStatus} />}
             />{' '}
         </div>
     );

--- a/src/components/content/order/OrderSubmitStatusPolling.tsx
+++ b/src/components/content/order/OrderSubmitStatusPolling.tsx
@@ -1,0 +1,162 @@
+import { useQuery } from '@tanstack/react-query';
+import { ServiceDetailVo, ServiceService } from '../../../xpanse-api/generated';
+import { OrderSubmitResult } from './OrderSubmitResult';
+import { OrderSubmitFailed } from './OrderSubmitFailed';
+import { ProcessingStatus } from './ProcessingStatus';
+import { OperationType } from './formElements/CommonTypes';
+import { useStopwatch } from 'react-timer-hook';
+import { useEffect } from 'react';
+import { deploymentStatusPollingInterval } from '../../utils/constants';
+
+function OrderSubmitStatusPolling({
+    uuid,
+    error,
+    isLoading,
+    userName,
+    setIsDeploying,
+    setRequestSubmitted,
+}: {
+    uuid: string | undefined;
+    error: Error | undefined;
+    isLoading: boolean;
+    userName: string;
+    setIsDeploying: (arg: boolean) => void;
+    setRequestSubmitted: (arg: boolean) => void;
+}): JSX.Element {
+    const getDeployedServiceDetailsByIdQuery = useQuery(
+        ['getDeployedServiceDetailsById', uuid, userName],
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        () => ServiceService.getDeployedServiceDetailsById(uuid!, userName),
+        {
+            refetchInterval: (data) =>
+                data?.serviceDeploymentState !== ServiceDetailVo.serviceDeploymentState.DEPLOYING
+                    ? false
+                    : deploymentStatusPollingInterval,
+            refetchIntervalInBackground: true,
+            refetchOnWindowFocus: false,
+            enabled: uuid !== undefined,
+        }
+    );
+
+    const stopWatch = useStopwatch({
+        autoStart: true,
+    });
+
+    useEffect(() => {
+        if (
+            getDeployedServiceDetailsByIdQuery.data &&
+            getDeployedServiceDetailsByIdQuery.data.serviceDeploymentState ===
+                ServiceDetailVo.serviceDeploymentState.DEPLOY_SUCCESS
+        ) {
+            setIsDeploying(false);
+            setRequestSubmitted(true);
+        }
+        if (
+            getDeployedServiceDetailsByIdQuery.data &&
+            ![
+                ServiceDetailVo.serviceDeploymentState.DEPLOYING,
+                ServiceDetailVo.serviceDeploymentState.DEPLOY_SUCCESS,
+            ].includes(getDeployedServiceDetailsByIdQuery.data.serviceDeploymentState)
+        ) {
+            setIsDeploying(false);
+            setRequestSubmitted(false);
+        }
+    }, [getDeployedServiceDetailsByIdQuery.data, setIsDeploying, setRequestSubmitted]);
+
+    useEffect(() => {
+        if (error) {
+            setIsDeploying(false);
+            setRequestSubmitted(false);
+        }
+    }, [error, setIsDeploying, setRequestSubmitted]);
+
+    useEffect(() => {
+        if (getDeployedServiceDetailsByIdQuery.error) {
+            setIsDeploying(false);
+        }
+    }, [getDeployedServiceDetailsByIdQuery.error, setIsDeploying]);
+
+    if (isLoading) {
+        return OrderSubmitResult(
+            'Request submission in-progress',
+            '-',
+            'success',
+            ServiceDetailVo.serviceDeploymentState.DEPLOYING,
+            stopWatch
+        );
+    }
+
+    if (error) {
+        return OrderSubmitFailed(error, ServiceDetailVo.serviceDeploymentState.DEPLOY_FAILED, stopWatch);
+    }
+
+    if (uuid && getDeployedServiceDetailsByIdQuery.error) {
+        return OrderSubmitResult(
+            'Deployment status polling failed. Please visit MyServices page to check the status of the request.',
+            uuid,
+            'error',
+            ServiceDetailVo.serviceDeploymentState.DEPLOY_FAILED,
+            stopWatch
+        );
+    }
+
+    if (
+        uuid &&
+        getDeployedServiceDetailsByIdQuery.data?.serviceDeploymentState ===
+            ServiceDetailVo.serviceDeploymentState.DEPLOYING
+    ) {
+        return OrderSubmitResult(
+            'Deploying, Please wait...',
+            uuid,
+            'success',
+            getDeployedServiceDetailsByIdQuery.data.serviceDeploymentState,
+            stopWatch
+        );
+    }
+
+    if (uuid !== undefined && getDeployedServiceDetailsByIdQuery.data === undefined) {
+        return OrderSubmitResult(
+            'Request accepted',
+            uuid,
+            'success',
+            ServiceDetailVo.serviceDeploymentState.DEPLOYING,
+            stopWatch
+        );
+    }
+
+    if (
+        uuid &&
+        getDeployedServiceDetailsByIdQuery.data &&
+        getDeployedServiceDetailsByIdQuery.data.serviceDeploymentState !==
+            ServiceDetailVo.serviceDeploymentState.DEPLOYING
+    ) {
+        if (
+            getDeployedServiceDetailsByIdQuery.data.serviceDeploymentState ===
+            ServiceDetailVo.serviceDeploymentState.DEPLOY_SUCCESS
+        ) {
+            return OrderSubmitResult(
+                ProcessingStatus(getDeployedServiceDetailsByIdQuery.data, OperationType.Deploy),
+                uuid,
+                'success',
+                getDeployedServiceDetailsByIdQuery.data.serviceDeploymentState,
+                stopWatch
+            );
+        }
+        if (
+            getDeployedServiceDetailsByIdQuery.data.serviceDeploymentState ===
+            ServiceDetailVo.serviceDeploymentState.DEPLOY_FAILED
+        ) {
+            return OrderSubmitResult(
+                ProcessingStatus(getDeployedServiceDetailsByIdQuery.data, OperationType.Deploy),
+                uuid,
+                'error',
+                getDeployedServiceDetailsByIdQuery.data.serviceDeploymentState,
+                stopWatch
+            );
+        }
+    }
+
+    return <></>;
+}
+
+export default OrderSubmitStatusPolling;

--- a/src/components/content/order/ServicesSkeleton.tsx
+++ b/src/components/content/order/ServicesSkeleton.tsx
@@ -12,8 +12,8 @@ function ServicesSkeleton() {
                 <Skeleton active={true} paragraph={{ rows: 0 }} />
             </div>
             <div className={'services-content-body'}>
-                {Array.from({ length: 9 }, () => (
-                    <Row key={0}>
+                {Array.from({ length: 9 }, (element, index) => (
+                    <Row key={index}>
                         <Col span={8} className={'services-content-body-col'}>
                             <Space direction='vertical' size='middle'>
                                 <div className={'service-type-option-detail-skeleton ant-skeleton-header'}>

--- a/src/components/content/order/useDeployRequestSubmitQuery.ts
+++ b/src/components/content/order/useDeployRequestSubmitQuery.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { CreateRequest, ServiceService } from '../../../xpanse-api/generated';
+
+export function useDeployRequestSubmitQuery() {
+    return useMutation({
+        mutationFn: (createRequest: CreateRequest) => {
+            return ServiceService.deploy(createRequest);
+        },
+    });
+}

--- a/src/components/utils/constants.tsx
+++ b/src/components/utils/constants.tsx
@@ -35,6 +35,7 @@ export const fetchMonitorMetricDataTimeInterval: number = 60 * 1000;
 export const deployTimeout: number = 3600000;
 // 5 seconds.
 export const waitServicePeriod: number = 5000;
+export const deploymentStatusPollingInterval: number = 5000;
 
 export const destroyTimeout: number = 3600000;
 

--- a/src/styles/service_order.css
+++ b/src/styles/service_order.css
@@ -313,3 +313,18 @@
 .migrate-show-deploy-class {
     height: 50%;
 }
+
+.timer-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.timer-header {
+    font-size: 10px;
+    font-weight: bold;
+}
+
+.timer-value {
+    font-size: 20px;
+}


### PR DESCRIPTION
Fixes eclipse-xpanse/xpanse#628
replaced API calls and removed boilerplate code for deployment timer.

![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/54129659/d4b83699-4f9d-4bf8-9bbf-80353530c200)
![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/54129659/c28600b4-739c-4383-9d36-dba16ce1e89c)
![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/54129659/f725942b-9213-4bd1-a24c-97201f80028d)
