### PR TITLE
end point details not fully displayed on unmask

### DIFF
--- a/src/styles/my_services.css
+++ b/src/styles/my_services.css
@@ -24,7 +24,7 @@
     font-size: 14px;
 }
 .show-details {
-    width: 55%;
+    width: 80%;
     height: 55%;
 }
 .details-content {


### PR DESCRIPTION
Fixed eclipse-xpanse/xpanse#864
![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/122504203/a09e6e67-19c8-4a99-ae3b-82a2a13f15bb)
