### PR TITLE
fix color of copy to clipboard icon

### DIFF
--- a/src/components/content/common/convertMapToDetailsList.tsx
+++ b/src/components/content/common/convertMapToDetailsList.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { Input, Typography } from 'antd';
-import { EyeInvisibleOutlined, EyeTwoTone } from '@ant-design/icons';
+import { CheckOutlined, CopyOutlined, EyeInvisibleOutlined, EyeTwoTone } from '@ant-design/icons';
 
 export function convertMapToDetailsList(content: Map<string, string>, title: string): React.JSX.Element {
     if (content.size > 0) {
@@ -18,7 +18,15 @@ export function convertMapToDetailsList(content: Map<string, string>, title: str
                         <div className={'service-instance-list-detail '}>{k}:&nbsp;&nbsp;</div>
                         {title.includes('Endpoint Information') ? (
                             <div className={'show-details'}>
-                                <Paragraph copyable={{ text: v }}>
+                                <Paragraph
+                                    copyable={{
+                                        text: v,
+                                        icon: [
+                                            <CopyOutlined className={'show-details-typography-copy'} />,
+                                            <CheckOutlined className={'show-details-typography-copy'} />,
+                                        ],
+                                    }}
+                                >
                                     <Input.Password
                                         readOnly={true}
                                         bordered={false}

--- a/src/styles/my_services.css
+++ b/src/styles/my_services.css
@@ -1,6 +1,7 @@
 .service-instance-list {
     margin-top: 15px;
 }
+
 .service-instance-list-detail {
     font-weight: bold;
 }
@@ -23,10 +24,16 @@
 .my-service-status-size {
     font-size: 14px;
 }
+
 .show-details {
     width: 55%;
     height: 55%;
 }
+
 .details-content {
     margin-bottom: 15px;
+}
+
+.show-details-typography-copy {
+    color: rgba(0, 0, 0, 0.45) !important;
 }


### PR DESCRIPTION
Fixed eclipse-xpanse/xpanse#865
![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/122504203/2d18267a-68d7-413f-84de-d6858edce5b0)
![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/122504203/f791e13c-4427-4383-ad12-e48a9fb10b3a)
