### PR TITLE
Enable operation 'details' when service state is `deploy failed`

### DIFF
--- a/src/components/content/deployedServices/myServices/MyServices.tsx
+++ b/src/components/content/deployedServices/myServices/MyServices.tsx
@@ -179,8 +179,7 @@ function MyServices(): React.JSX.Element {
             {
                 key: 'details',
                 label:
-                    record.serviceDeploymentState === DeployedService.serviceDeploymentState.DESTROY_SUCCESSFUL ||
-                    record.serviceDeploymentState === DeployedService.serviceDeploymentState.DEPLOYMENT_FAILED ? (
+                    record.serviceDeploymentState === DeployedService.serviceDeploymentState.DESTROY_SUCCESSFUL ? (
                         <Tooltip title='Please contact the service provider'>
                             <Button
                                 onClick={() => {


### PR DESCRIPTION
fixes https://github.com/eclipse-xpanse/xpanse/issues/1301