### PR TITLE
After successful deployment, there is a line break problem in the endpoint information style in the prompt.

### DIFF
--- a/src/styles/my_services.css
+++ b/src/styles/my_services.css
@@ -10,6 +10,7 @@
 
 .service-instance-list-detail {
     font-weight: bold;
+    white-space: nowrap;
 }
 
 .service-instance-detail-position {


### PR DESCRIPTION
Fixed eclipse-xpanse/xpanse#1356
![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/122504203/acc2aefd-521c-42f9-9999-915eadf1fb82)
