### PR TITLE
BillingMode shown in different color in the Migration final page

### DIFF
--- a/src/components/content/order/common/MigrateServiceSubmitBillingMode.tsx
+++ b/src/components/content/order/common/MigrateServiceSubmitBillingMode.tsx
@@ -19,7 +19,7 @@ export const MigrateServiceSubmitBillingMode = ({ selectBillMode }: { selectBill
                     required={true}
                 >
                     <Flex vertical gap='middle'>
-                        <Radio.Group disabled={true} buttonStyle='solid' value={selectBillMode}>
+                        <Radio.Group disabled={true} buttonStyle='solid'>
                             <Radio.Button key={selectBillMode} value={selectBillMode}>
                                 {selectBillMode}
                             </Radio.Button>


### PR DESCRIPTION
Fixed eclipse-xpanse/xpanse#1666
![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/122504203/a53a65ba-e44a-45df-bde3-f6d943777c2a)
