### PR TITLE
Add retry buttons to dashboard failure alerts

### DIFF
--- a/src/components/content/home/common/DashBoardError.tsx
+++ b/src/components/content/home/common/DashBoardError.tsx
@@ -3,13 +3,19 @@
  * SPDX-FileCopyrightText: Huawei Inc.
  */
 
-import { Alert, Card } from 'antd';
+import { Alert, Button, Card } from 'antd';
 import React from 'react';
 import errorAlertStyles from '../../../../styles/error-alert.module.css';
 import { ApiError, Response } from '../../../../xpanse-api/generated';
 import { convertStringArrayToUnorderedList } from '../../../utils/generateUnorderedList';
 
-export default function DashBoardError({ error }: { error: unknown }): React.JSX.Element {
+export default function DashBoardError({
+    error,
+    retryRequest,
+}: {
+    error: unknown;
+    retryRequest: () => void;
+}): React.JSX.Element {
     if (error instanceof ApiError && error.body && 'details' in error.body) {
         const response: Response = error.body as Response;
         return (
@@ -20,6 +26,17 @@ export default function DashBoardError({ error }: { error: unknown }): React.JSX
                     type={'error'}
                     closable={false}
                     className={errorAlertStyles.errorFailureAlert}
+                    action={
+                        <Button
+                            className={errorAlertStyles.tryAgainBtnInAlertClass}
+                            size='small'
+                            type='primary'
+                            onClick={retryRequest}
+                            danger={true}
+                        >
+                            Retry Request
+                        </Button>
+                    }
                 />
             </Card>
         );
@@ -32,6 +49,17 @@ export default function DashBoardError({ error }: { error: unknown }): React.JSX
                     type={'error'}
                     closable={false}
                     className={errorAlertStyles.errorFailureAlert}
+                    action={
+                        <Button
+                            className={errorAlertStyles.tryAgainBtnInAlertClass}
+                            size='small'
+                            type='primary'
+                            onClick={retryRequest}
+                            danger={true}
+                        >
+                            Retry Request
+                        </Button>
+                    }
                 />
             </Card>
         );

--- a/src/components/content/home/isv/IsvServicesDashBoard.tsx
+++ b/src/components/content/home/isv/IsvServicesDashBoard.tsx
@@ -24,6 +24,12 @@ export function IsvServicesDashBoard(): React.JSX.Element {
     let registeredServicesCount: number = 0;
     const navigate = useNavigate();
 
+    const retryRequest = () => {
+        if (listDeployedServicesByIsvQuery.isError) {
+            void listDeployedServicesByIsvQuery.refetch();
+        }
+    };
+
     if (listDeployedServicesByIsvQuery.data !== undefined && listDeployedServicesByIsvQuery.data.length > 0) {
         listDeployedServicesByIsvQuery.data.forEach((serviceItem: DeployedService) => {
             if (
@@ -56,7 +62,7 @@ export function IsvServicesDashBoard(): React.JSX.Element {
             ? listDeployedServicesByIsvQuery.error
             : listRegisteredServicesByIsvQuery.error;
 
-        return <DashBoardError error={errorToDisplay} />;
+        return <DashBoardError error={errorToDisplay} retryRequest={retryRequest} />;
     }
 
     if (

--- a/src/components/content/home/user/EndUserServicesDashboard.tsx
+++ b/src/components/content/home/user/EndUserServicesDashboard.tsx
@@ -22,8 +22,14 @@ export function EndUserServicesDashboard(): React.JSX.Element {
     let successfulDestroysCount: number = 0;
     let failedDestroysCount: number = 0;
 
+    const retryRequest = () => {
+        if (listDeployedServicesQuery.isError) {
+            void listDeployedServicesQuery.refetch();
+        }
+    };
+
     if (listDeployedServicesQuery.isError) {
-        return <DashBoardError error={listDeployedServicesQuery.error} />;
+        return <DashBoardError error={listDeployedServicesQuery.error} retryRequest={retryRequest} />;
     }
 
     if (listDeployedServicesQuery.isPending || listDeployedServicesQuery.isFetching) {


### PR DESCRIPTION
Fixed eclipse-xpanse/xpanse#1682
![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/122504203/82baa1e9-5e3a-4e0d-aecf-26ef00a35002)
![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/122504203/a8df2133-96af-492b-9f45-65dfd3310657)
