### PR TITLE
enable 'back' button when deployment fails

### DIFF
--- a/src/components/content/order/create/NavigateOrderSubmission.tsx
+++ b/src/components/content/order/create/NavigateOrderSubmission.tsx
@@ -15,10 +15,12 @@ function NavigateOrderSubmission({
     text,
     to,
     props,
+    disabled,
 }: {
     text: string;
     to: To;
     props?: OrderSubmitProps;
+    disabled:boolean;
 }): React.JSX.Element {
     const navigate = useNavigate();
     const [resetFormCache] = useOrderFormStore((state) => [state.clearFormVariables]);
@@ -38,6 +40,7 @@ function NavigateOrderSubmission({
                 goBack(props);
             }}
             className={serviceOrderStyles.orderNavigate}
+            disabled={disabled}
         >
             {text}
         </Button>

--- a/src/components/content/order/create/NavigateOrderSubmission.tsx
+++ b/src/components/content/order/create/NavigateOrderSubmission.tsx
@@ -20,7 +20,7 @@ function NavigateOrderSubmission({
     text: string;
     to: To;
     props?: OrderSubmitProps;
-    disabled:boolean;
+    disabled: boolean;
 }): React.JSX.Element {
     const navigate = useNavigate();
     const [resetFormCache] = useOrderFormStore((state) => [state.clearFormVariables]);

--- a/src/components/content/order/create/OrderSubmit.tsx
+++ b/src/components/content/order/create/OrderSubmit.tsx
@@ -178,9 +178,12 @@ function OrderSubmit(state: OrderSubmitProps): React.JSX.Element {
                                         text={'Back'}
                                         to={createServicePageUrl as To}
                                         props={state}
-                                        disabled={getServiceDetailsByIdQuery.data?.serviceDeploymentState.toString() ===
-                                            serviceDeploymentState.DEPLOYING.toString() || getServiceDetailsByIdQuery.data?.serviceDeploymentState.toString() ===
-                                            serviceDeploymentState.DEPLOYMENT_SUCCESSFUL.toString()}
+                                        disabled={
+                                            getServiceDetailsByIdQuery.data?.serviceDeploymentState.toString() ===
+                                                serviceDeploymentState.DEPLOYING.toString() ||
+                                            getServiceDetailsByIdQuery.data?.serviceDeploymentState.toString() ===
+                                                serviceDeploymentState.DEPLOYMENT_SUCCESSFUL.toString()
+                                        }
                                     />
                                 </div>
                             </Col>

--- a/src/components/content/order/create/OrderSubmit.tsx
+++ b/src/components/content/order/create/OrderSubmit.tsx
@@ -178,6 +178,9 @@ function OrderSubmit(state: OrderSubmitProps): React.JSX.Element {
                                         text={'Back'}
                                         to={createServicePageUrl as To}
                                         props={state}
+                                        disabled={getServiceDetailsByIdQuery.data?.serviceDeploymentState.toString() ===
+                                            serviceDeploymentState.DEPLOYING.toString() || getServiceDetailsByIdQuery.data?.serviceDeploymentState.toString() ===
+                                            serviceDeploymentState.DEPLOYMENT_SUCCESSFUL.toString()}
                                     />
                                 </div>
                             </Col>

--- a/src/components/content/order/create/SelectServiceForm.tsx
+++ b/src/components/content/order/create/SelectServiceForm.tsx
@@ -389,7 +389,12 @@ export function SelectServiceForm({ services }: { services: UserOrderableService
                 <Row justify='space-around'>
                     <Col span={6}>
                         <div>
-                            <NavigateOrderSubmission text={'Back'} to={servicePageUrl as To} props={undefined} />
+                            <NavigateOrderSubmission
+                                text={'Back'}
+                                to={servicePageUrl as To}
+                                props={undefined}
+                                disabled={false}
+                            />
                         </div>
                     </Col>
                     <Col span={4}>


### PR DESCRIPTION
Fixed eclipse-xpanse/xpanse#1686
![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/122504203/1a8734d9-9f26-4bd5-842c-e5a1619a2f7b)
![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/122504203/8c65e2ad-d05e-4a88-8875-1fe4a63efa5f)

![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/122504203/8addf2cd-2e87-4225-bfbc-a38f7e6651d4)
![image](https://github.com/eclipse-xpanse/xpanse-ui/assets/122504203/bda73d85-d960-40a6-9a14-acbdaef1b580)
