### PR TITLE
make the order ID copy function work correctly.

### DIFF
--- a/src/components/content/order/orderStatus/OrderSubmitResultDetails.tsx
+++ b/src/components/content/order/orderStatus/OrderSubmitResultDetails.tsx
@@ -56,7 +56,7 @@ function OrderSubmitResultDetails({
                 <Paragraph
                     className={submitResultStyles.resultMainDetails}
                     copyable={{
-                        text: String(serviceId),
+                        text: String(orderId),
                         icon: [
                             <CopyOutlined className={submitResultStyles.showDetailsTypographyCopy} key={uuidv4()} />,
                             <CheckOutlined className={submitResultStyles.showDetailsTypographyCopy} key={uuidv4()} />,


### PR DESCRIPTION
fixes https://github.com/eclipse-xpanse/xpanse/issues/2479

all types share this one file.

![Snipaste_2025-03-05_15-37-54-scale](https://github.com/user-attachments/assets/885ab456-6700-4178-8cf9-f88f1e564b97)
