### PR TITLE
disable actions operation when service id destroyed

### DIFF
--- a/src/components/content/deployedServices/myServices/MyServices.tsx
+++ b/src/components/content/deployedServices/myServices/MyServices.tsx
@@ -105,6 +105,7 @@ import {
     isDisableModifyBtn,
     isDisableRecreateBtn,
     isDisableRetryDeploymentBtn,
+    isDisableServiceActionBtn,
     isDisableServiceConfigBtn,
     isDisableServicePortingBtn,
     isDisableStartBtn,
@@ -813,6 +814,7 @@ function MyServices(): React.JSX.Element {
                             handleServiceActionsOpenModal(record);
                         }}
                         className={myServicesStyles.buttonAsLink}
+                        disabled={isDisableServiceActionBtn(record)}
                         icon={<FileTextOutlined />}
                         type={'link'}
                     >

--- a/src/components/content/deployedServices/myServices/myServiceProps.tsx
+++ b/src/components/content/deployedServices/myServices/myServiceProps.tsx
@@ -350,10 +350,7 @@ export const isDisabledStopOrRestartBtn = (
 };
 
 export const isDisableRetryDeploymentBtn = (record: DeployedService) => {
-    if (record.serviceDeploymentState === serviceDeploymentState.DEPLOYING) {
-        return true;
-    }
-    return false;
+    return record.serviceDeploymentState === serviceDeploymentState.DEPLOYING;
 };
 
 export const isDisableServiceConfigBtn = (record: DeployedService) => {
@@ -367,6 +364,14 @@ export const isDisableServiceConfigBtn = (record: DeployedService) => {
         }
     }
     return true;
+};
+
+export const isDisableServiceActionBtn = (record: DeployedService) => {
+    return !(
+        record.serviceDeploymentState === serviceDeploymentState.DEPLOYMENT_SUCCESSFUL ||
+        record.serviceDeploymentState === serviceDeploymentState.DESTROY_FAILED ||
+        record.serviceDeploymentState === serviceDeploymentState.MODIFICATION_SUCCESSFUL
+    );
 };
 
 export const isDisableRecreateBtn = (
@@ -393,14 +398,11 @@ export const isDisableRecreateBtn = (
         return true;
     }
 
-    if (
+    return (
         record.serviceState === serviceState.STARTING ||
         record.serviceState === serviceState.STOPPING ||
         record.serviceState === serviceState.RESTARTING
-    ) {
-        return true;
-    }
-    return false;
+    );
 };
 
 export interface Option {


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/2509
Related to https://github.com/eclipse-xpanse/xpanse/pull/2510

![chrome_MRGTg1B7KN](https://github.com/user-attachments/assets/1992a713-c1d3-4ba1-b163-ca0d7f5c6df3)
