### PR TITLE
show destroy button as disabled when destroy is locked.

### DIFF
--- a/src/components/content/deployedServices/myServices/MyServices.tsx
+++ b/src/components/content/deployedServices/myServices/MyServices.tsx
@@ -670,7 +670,7 @@ function MyServices(): React.JSX.Element {
                                         className={myServicesStyles.buttonAsLink}
                                         type={'link'}
                                     >
-                                        purge
+                                        destroy
                                     </Button>
                                     <LockOutlined />
                                 </Tooltip>


### PR DESCRIPTION
fixes https://github.com/eclipse-xpanse/xpanse/issues/2586